### PR TITLE
Change content for check in order to avoid 404

### DIFF
--- a/src/atcoder.ts
+++ b/src/atcoder.ts
@@ -45,8 +45,8 @@ export class AtCoder {
 	 * アクセスしてログインしている状態かどうかを取得する(結果をキャッシュしない)
 	 */
 	private async check(): Promise<boolean> {
-		// practice contestでログインせず提出ページにアクセスするとコンテストトップに飛ばされることを利用する
-		const url = `${AtCoder.getContestURL("practice")}/submit`;
+		// ログインせず提出ページにアクセスするとコンテストトップに飛ばされることを利用する
+		const url = `${AtCoder.getContestURL("abc001")}/submit`;
 		// リダイレクトを無効化・302コードを容認して通信
 		const response = await this.session.get(url, {
 			maxRedirects: 0,


### PR DESCRIPTION
# Summary of Bug

Once the user logins, any command fails because of 404.

# Cause

If the user doesn't participate in practice contest, `https://atcoder.jp/contests/practice/submit` gets 404. Consequently, `check` method of `AtCoder` class always fails.

# Fix

I changed the contest for `check` from Practice Contest to ABC001, which doesn't require participation.