### PR TITLE
Allow template file to omit contest template

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -85,8 +85,7 @@ export async function validateTemplateJSON(data: RawTemplate): Promise<[true, nu
  * @param log default=false trueなら通常ログを標準出力に表示させる falseの場合はエラーログのみをエラー出力に表示
  */
 export async function installContestTemplate(contest: Contest, template: Template, contest_path: string, log: boolean = false) {
-	const contest_template = template.contest;
-	if (contest_template === undefined) throw new Error("no contest template is given");
+	const contest_template = template.contest !== undefined ? template.contest : {};
 	// 現在のディレクトリを記憶しつつ展開先ディレクトリに移動する
 	const pwd = process.cwd();
 	process.chdir(contest_path);


### PR DESCRIPTION
# Summary of Bug

According to README.md, contest template is optional. However, when omitting `contest` parameter in `template.json`, `acc new` doesn't create task directories.

# How to Reproduce

Place the following files in config directory.

- `rust/template.json`:
  ```
  {
    "task": {
      "program": ["main.rs"],
      "submit": "main.rs"
    }
  }
  ```
- `rust/main.rs`: empty file

Then execute `acc new --template rust abc001`. It shows an error message: `no contest template is given`, and no task directories are created.

# Fix

 I gave an empty object as the default value of `contest`.