### PR TITLE
Pass online-judge the option to force submit

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -222,7 +222,7 @@ export async function submit(filename: string | undefined, options: { task?: str
 	}
 	console.log(`submit to: ${url}`);
 	// 提出
-	await OnlineJudge.call(["s", url, filename]);
+	await OnlineJudge.call(["s", "-y", url, filename]);
 }
 
 export async function checkOJAvailable() {


### PR DESCRIPTION
When executing `acc submit`, online-judge-tools always requires confirmation:

```
[!] the problem "http://abc119.contest.atcoder.jp/tasks/abc119_a" is specified to submit, but no samples were downloaded in this directory. this may be mis-operation
[x] sleep(3.00)
Are you sure? Please type "abca" 
```

That is because the directory hierarchy of atcoder-cli differs from that of online-judge-tools. However, this is usually not a mis-operation.

So, I added a parameter passed to online-judge-tools for avoiding this confirmation.