### PR TITLE
Abstracted Interface between AtCoder, Session and Cookie

### DIFF
--- a/src/atcoder.ts
+++ b/src/atcoder.ts
@@ -97,9 +97,7 @@ export class AtCoder {
 		if (result) {
 			// ログインに成功していた場合はセッション情報を保存する
 			const new_cookies = Cookie.convertSetCookies2CookieArray(response.headers["set-cookie"]);
-			const session_cookies = await this.session.getCookies();
-			session_cookies.set(new_cookies);
-			session_cookies.saveConfigFile();
+			await this.session.saveSessionFromCookies(new_cookies);
 		}
 		return result;
 	}

--- a/src/atcoder.ts
+++ b/src/atcoder.ts
@@ -1,4 +1,4 @@
-import {Session} from "./session";
+import {Session, SessionInterface} from "./session";
 import {Cookie} from "./cookie";
 import querystring from "query-string";
 import {Contest, Task} from "./project";
@@ -22,11 +22,11 @@ export class AtCoder {
 		return `${AtCoder.getContestURL(contest)}/tasks${task === undefined ? "" : `/${task}`}`;
 	}
 
-	private session: Session;
+	private session: SessionInterface;
 	// null:未検査 true/false: ログインしているかどうか
 	private _login: boolean | null;
 
-	constructor(session: Session) {
+	constructor(session: SessionInterface) {
 		this.session = session;
 		this._login = null;
 	}

--- a/src/atcoder.ts
+++ b/src/atcoder.ts
@@ -1,4 +1,4 @@
-import {Session, SessionInterface} from "./session";
+import {SessionInterface} from "./session";
 import {Cookie} from "./cookie";
 import querystring from "query-string";
 import {Contest, Task} from "./project";

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -30,7 +30,7 @@ export interface CookieConstructorInterface {
 	/**
 	 * 設定ファイルからcookie情報を読み込み済みのインスタンスを生成
 	 */
-	createLoadedInstance(): Promise<Cookie>
+	createLoadedInstance(): Promise<CookieInterface>
 }
 
 /**

--- a/src/cookie.ts
+++ b/src/cookie.ts
@@ -2,12 +2,43 @@ import {name as projectName} from "../package.json";
 // yummy!
 type CookieConf = import("conf")<Array<string>>;
 
+export interface CookieInterface {
+	/**
+	 * 現在保持しているcookieを取得
+	 */
+	get(): Array<string>;
+	/**
+	 * 現在保持しているcookieを新しいものに置き換える
+	 * @param cookies 新しく保持するcookie全体を表す、"key=value"形式の文字列の配列
+	 */
+	set(cookies: Array<string>): void;
+	/**
+	 * 現在保持しているcookieを捨てる
+	 */
+	empty(): void;
+	/**
+	 * 設定ファイルからcookieを読み込んで保持する
+	 */
+	loadConfigFile(): Promise<void>;
+	/**
+	 * 現在保持しているcookieを設定ファイルに書き出す
+	 */
+	saveConfigFile(): Promise<void>;
+}
+
+export interface CookieConstructorInterface {
+	/**
+	 * 設定ファイルからcookie情報を読み込み済みのインスタンスを生成
+	 */
+	createLoadedInstance(): Promise<Cookie>
+}
+
 /**
  * Cookie管理用クラス
  * cookieはHTTPリクエストヘッダにおける Cookie: a=b; c=d
  * の"a=b", "c=d"の部分を文字列の配列として管理する
  */
-export class Cookie {
+export class Cookie implements CookieInterface {
 	private cookies: Array<string>;
 	private static _cookie_conf: CookieConf | null = null;
 

--- a/src/di/index.ts
+++ b/src/di/index.ts
@@ -1,13 +1,13 @@
 import {Design, Injector} from "typesafe-di";
-import { Session } from "../session";
+import { Session, SessionInterface } from "../session";
 import { AtCoder } from "../atcoder";
-import { Cookie } from "../cookie";
+import { CookieConstructorInterface, Cookie } from "../cookie";
 
 interface HasCookieConstructor {
-    CookieConstructor: typeof Cookie;
+    CookieConstructor: CookieConstructorInterface;
 }
 interface HasSession {
-    session: Session;
+    session: SessionInterface;
 }
 
 export const CookieDesign = Design.bind('CookieConstructor', ()=> Cookie)

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,4 +1,4 @@
-import {Cookie, CookieConstructorInterface, CookieInterface} from "./cookie";
+import {CookieConstructorInterface, CookieInterface} from "./cookie";
 
 type AxiosRequestConfig = import("axios").AxiosRequestConfig;
 type AxiosResponse = import("axios").AxiosResponse;

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,18 +1,24 @@
-import {Cookie} from "./cookie";
+import {Cookie, CookieConstructorInterface, CookieInterface} from "./cookie";
 
 type AxiosRequestConfig = import("axios").AxiosRequestConfig;
 type AxiosResponse = import("axios").AxiosResponse;
+
+export interface SessionInterface {
+	get(url: string, options?: AxiosRequestConfig): Promise<AxiosResponse>;
+	post(url: string, data?: any, options?: AxiosRequestConfig): Promise<AxiosResponse>;
+	getCookies(): Promise<CookieInterface>;
+}
 
 /**
  * セッション管理用クラス
  * こいつでcookieを使いまわしてログイン認証した状態でデータをとってくる
  */
-export class Session {
+export class Session implements SessionInterface {
 	private static _axios: import("axios").AxiosInstance | null = null;
-	private CookieConstructor: typeof Cookie
-	private _cookies: Cookie | null;
+	private CookieConstructor: CookieConstructorInterface
+	private _cookies: CookieInterface | null;
 
-	constructor(CookieConstructor: typeof Cookie) {
+	constructor(CookieConstructor: CookieConstructorInterface) {
 		this.CookieConstructor = CookieConstructor
 		this._cookies = null;
 	}
@@ -27,7 +33,7 @@ export class Session {
 		return Session._axios;
 	}
 
-	async getCookies(): Promise<Cookie> {
+	async getCookies(): Promise<CookieInterface> {
 		if (this._cookies === null) {
 			return this._cookies = await this.CookieConstructor.createLoadedInstance();
 		}

--- a/src/session.ts
+++ b/src/session.ts
@@ -6,7 +6,7 @@ type AxiosResponse = import("axios").AxiosResponse;
 export interface SessionInterface {
 	get(url: string, options?: AxiosRequestConfig): Promise<AxiosResponse>;
 	post(url: string, data?: any, options?: AxiosRequestConfig): Promise<AxiosResponse>;
-	getCookies(): Promise<CookieInterface>;
+	saveSessionFromCookies(cookies: Array<string>): Promise<void>;
 }
 
 /**
@@ -56,5 +56,11 @@ export class Session implements SessionInterface {
 			},
 			...options
 		})
+	}
+
+	async saveSessionFromCookies(cookies: Array<string>): Promise<void> {
+		const session_cookies = await this.getCookies();
+		session_cookies.set(cookies);
+		await session_cookies.saveConfigFile();
 	}
 }


### PR DESCRIPTION
This PR defines new `SessionInterface` and `CookieInterface` so that these classes no longer depend on actual implementation but required interfaces.

This PR also does one refactoring so that `AtCoder` doesn't depend on interface of `Cookie`.