### PR TITLE
remove wrong help text

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -25,7 +25,6 @@ export const format_strings = `Supported format strings:
 export const global_config = `Global config options list:
   oj-path                         install path of online-judge-tools (auto detected)
   default-contest-dirname-format  default name of contest directory (created by \`acc new\` command)
-  default-new-contest-cmd         default --cmd option for \`acc new\` command (see also: \`acc new -h\`)
   default-task-dirname-format     default name of task directory (created by \`acc new|add\` command)
   default-test-dirname-format     default name of sample cases directory
   default-task-choice             default --choice option for \`acc new|add\` command (see also: \`acc new|add -h\`)

--- a/tests/__tests__/cli.ts
+++ b/tests/__tests__/cli.ts
@@ -45,7 +45,6 @@ describe("command calls", () => {
 			run("new", "abc104", "-t", "{TASKLABEL}");
 			expect(commands.setup).toBeCalledWith("abc104", expect.objectContaining({taskDirnameFormat: "{TASKLABEL}"}));
 		});
-		// NOTE: not implemented option
 		test("new abc105 -d {ContestTitle}", () => {
 			const commands = require("../../src/commands");
 			run("new", "abc105", "-d", "{ContestTitle}");


### PR DESCRIPTION
closes #10 
I decided NOT to implement `default-new-contest-cmd` global config option.
It can be covered by template, and it has a risk for user to forget that some command will be executed automatically.