### PR TITLE
Enable to pass arguments to online-judge-tools in submit command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.1.0]
+### Added
+- enable to pass arguments to online-judge-tools in submit command and add --skip-filename option
+
+
 ## [2.0.5]
 ### Added
 - This CHANGELOG! ([#21](https://github.com/Tatamo/atcoder-cli/pull/21))

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -43,10 +43,11 @@ commander
 	});
 
 commander
-	.command("submit [filename]")
+	.command("submit [filename] [facade-options...]")
 	.alias("s")
 	.option("-c, --contest <contest-id>", "specify contest id to submit")
 	.option("-t, --task <task-id>", "specify task id to submit")
+	.option("-s, --skip-filename", "specify that filename is not given (the first argument will be parsed as not a filename, but a facade option)")
 	.action(commands.submit)
 	.description("submit the program");
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -49,7 +49,11 @@ commander
 	.option("-t, --task <task-id>", "specify task id to submit")
 	.option("-s, --skip-filename", "specify that filename is not given (the first argument will be parsed as not a filename, but a facade option)")
 	.action(commands.submit)
-	.description("submit the program");
+	.description("submit the program")
+	.on("--help", () => {
+		console.log("");
+		console.log(help.submit_facade_options);
+	});
 
 commander
 	.command("login")

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -190,6 +190,13 @@ export async function format(format_string: string, contest_id: string, task_id?
 export async function submit(filename: string | undefined, facade_options: Array<string>, options: { task?: string, contest?: string, skipFilename?: boolean }) {
 	let contest_id = options.contest;
 	let task_id = options.task;
+	const f_skip_filename = options.skipFilename === true;
+
+	// treat filename as a first facade option and assume that filename is not given
+	if (f_skip_filename && filename !== undefined) {
+		facade_options.unshift(filename);
+		filename = undefined;
+	}
 	if (filename === undefined || contest_id === undefined || task_id === undefined) {
 		// ファイル名、タスク、コンテストのいずれかが未指定の場合、カレントディレクトリのパスから提出先を調べる
 		const {contest, task} = await detectTaskByPath();
@@ -223,7 +230,7 @@ export async function submit(filename: string | undefined, facade_options: Array
 	}
 	console.log(`submit to: ${url}`);
 	// 提出
-	await OnlineJudge.call(["s", url, filename]);
+	await OnlineJudge.call(["s", url, filename, ...facade_options]);
 }
 
 export async function checkOJAvailable() {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,7 +3,7 @@ import {OnlineJudge} from "./facade/oj";
 import {Contest, Task, detectTaskByPath, findProjectJSON, formatTaskDirname, saveProjectJSON, init, installTask, formatContestDirname} from "./project";
 import getConfig, {defaults, getConfigDirectory} from "./config";
 import {getTemplate, getTemplates, Template} from "./template";
-import { getAtCoder } from "./di";
+import {getAtCoder} from "./di";
 
 export async function login() {
 	const atcoder = await getAtCoder();
@@ -187,7 +187,7 @@ export async function format(format_string: string, contest_id: string, task_id?
 	}
 }
 
-export async function submit(filename: string | undefined, options: { task?: string, contest?: string }) {
+export async function submit(filename: string | undefined, facade_options: Array<string>, options: { task?: string, contest?: string, skipFilename?: boolean }) {
 	let contest_id = options.contest;
 	let task_id = options.task;
 	if (filename === undefined || contest_id === undefined || task_id === undefined) {

--- a/src/help.ts
+++ b/src/help.ts
@@ -37,4 +37,11 @@ export const online_judge_tools = `Functions of online-judge-tools linkage:
   downloading sample cases  \`acc new|add\` command
   submit code               \`acc submit\` command`;
 
+export const submit_facade_options = `atcoder-cli uses online-judge-tools internally.
+pass extra arguments to online-judge-tools:
+  \`acc submit main.cpp -- -w 10 --no-open\`
+  
+If you are using template and want to omit the filename, use -s option:
+  \`acc submit -s -- -w 10 --no-open\``;
+
 export const default_help = `to get detailed information, use \`acc <command> -h\``;

--- a/tests/__tests__/cli.ts
+++ b/tests/__tests__/cli.ts
@@ -100,6 +100,13 @@ describe("command calls", () => {
 			expect(commands.submit).toBeCalledWith("-y", ["--no-open", "-w", "10"], expect.objectContaining({skipFilename: true}));
 			expect(commands.submit).toBeCalledWith("-y", ["--no-open", "-w", "10"], expect.not.objectContaining({contest: expect.anything(), task: expect.anything()}));
 		});
+		test("s -s --", () => {
+			const commands = require("../../src/commands");
+			run("s", "-s", "--");
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.anything());
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.objectContaining({skipFilename: true}));
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.not.objectContaining({contest: expect.anything(), task: expect.anything()}));
+		});
 		test("s -c abc100 -t abc100_a", () => {
 			const commands = require("../../src/commands");
 			run("s", "-c", "abc100", "-t", "abc100_a");

--- a/tests/__tests__/cli.ts
+++ b/tests/__tests__/cli.ts
@@ -79,18 +79,32 @@ describe("command calls", () => {
 		test("submit", () => {
 			const commands = require("../../src/commands");
 			run("submit");
-			expect(commands.submit).toBeCalledWith(undefined, expect.anything());
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.anything());
 		});
 		test("s main.cpp", () => {
 			const commands = require("../../src/commands");
 			run("s", "main.cpp");
-			expect(commands.submit).toBeCalledWith("main.cpp", expect.anything());
-			expect(commands.submit).toBeCalledWith("main.cpp", expect.not.objectContaining({contest: expect.anything(), task: expect.anything()}));
+			expect(commands.submit).toBeCalledWith("main.cpp", [], expect.anything());
+			expect(commands.submit).toBeCalledWith("main.cpp", [], expect.not.objectContaining({contest: expect.anything(), task: expect.anything(), skipFilename: expect.anything()}));
+		});
+		test("s main.cpp -- -y", () => {
+			const commands = require("../../src/commands");
+			run("s", "main.cpp", "--", "-y");
+			expect(commands.submit).toBeCalledWith("main.cpp", ["-y"], expect.anything());
+			expect(commands.submit).toBeCalledWith("main.cpp", ["-y"], expect.not.objectContaining({contest: expect.anything(), task: expect.anything(), skipFilename: expect.anything()}));
+		});
+		test("s -s -- -y --no-open -w 10", () => {
+			const commands = require("../../src/commands");
+			run("s", "-s", "--", "-y", "--no-open", "-w", "10");
+			expect(commands.submit).toBeCalledWith("-y", ["--no-open", "-w", "10"], expect.anything());
+			expect(commands.submit).toBeCalledWith("-y", ["--no-open", "-w", "10"], expect.objectContaining({skipFilename: true}));
+			expect(commands.submit).toBeCalledWith("-y", ["--no-open", "-w", "10"], expect.not.objectContaining({contest: expect.anything(), task: expect.anything()}));
 		});
 		test("s -c abc100 -t abc100_a", () => {
 			const commands = require("../../src/commands");
 			run("s", "-c", "abc100", "-t", "abc100_a");
-			expect(commands.submit).toBeCalledWith(undefined, expect.objectContaining({contest: "abc100", task: "abc100_a"}));
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.objectContaining({contest: "abc100", task: "abc100_a"}));
+			expect(commands.submit).toBeCalledWith(undefined, [], expect.not.objectContaining({skipFilename: expect.anything()}));
 		});
 	});
 	describe("acc login", () => {


### PR DESCRIPTION
`$ acc submit [filename] [facade-options...]`
`facade-options` variadic arguments added.
## Usage:
`$ acc submit main.cpp -- -y -w 10 --no-open`
Note that you must write `"--"` otherwise the following options are treated as options for atcoder-cli.

When you use a template, you can omit the filename argument.
So `$acc submit -- -y` is ambiguous, `-y` may be or may not be a filename.
To avoid this, I added `--skip-filename` (`-s`) option.
Without this, the `-y` above is treated as a filename.
Use `$acc submit -s -- -y` to pass `-y` option to oj.