### PR TITLE
contest.acc.json書き出し時に提出ファイルのformatが未展開になる不具合の修正

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -207,7 +207,7 @@ export async function installTask(detailed_task: DetailedTask, dirname: string, 
 	// 新しく情報を付与したTaskオブジェクトを返す
 	const s: any = {directory: {path: dirname}};
 	if (flg_tests) s.directory.testdir = testdir;
-	if (task_template !== undefined && task_template.submit !== undefined) s.directory.submit = task_template.submit;
+	if (task_template !== undefined && task_template.submit !== undefined) s.directory.submit = formatTaskDirname(task_template.submit, task, index, contest);
 	return Object.assign(task, s);
 }
 


### PR DESCRIPTION
fixes #36 

`template.json`
```
{
  "task": {
    "program": [["main.py", "{tasklabel}.py"]],
    "submit": "{tasklabel}.py"
  }
}
```

のように `submit` にformat文字列が指定されていた場合に正しく展開が行われず、結果として提出時にファイル名を省略するとエラーになる不具合の修正です。