### PR TITLE
implemented params to pass to oj submit command

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -42,12 +42,16 @@ commander
 		console.log(help.task_choices);
 	});
 
+function collect(value : string, previous : string[]) {
+  return previous.concat([value]);
+};
 commander
 	.command("submit [filename] [facade-options...]")
 	.alias("s")
 	.option("-c, --contest <contest-id>", "specify contest id to submit")
 	.option("-t, --task <task-id>", "specify task id to submit")
 	.option("-s, --skip-filename", "specify that filename is not given (the first argument will be parsed as not a filename, but a facade option)")
+    .option('-j, --oj-options <value>', 'specify oj params to be passed', collect, [])
 	.action(commands.submit)
 	.description("submit the program")
 	.on("--help", () => {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -187,7 +187,7 @@ export async function format(format_string: string, contest_id: string, task_id?
 	}
 }
 
-export async function submit(filename: string | undefined, facade_options: Array<string>, options: { task?: string, contest?: string, skipFilename?: boolean }) {
+export async function submit(filename: string | undefined, facade_options: Array<string>, options: { task?: string, contest?: string, skipFilename?: boolean, ojOptions: Array<string>}) {
 	let contest_id = options.contest;
 	let task_id = options.task;
 	const f_skip_filename = options.skipFilename === true;
@@ -230,7 +230,7 @@ export async function submit(filename: string | undefined, facade_options: Array
 	}
 	console.log(`submit to: ${url}`);
 	// 提出
-	await OnlineJudge.call(["s", url, filename, ...facade_options]);
+	await OnlineJudge.call(["s", url, filename, ...facade_options, ...options.ojOptions]);
 }
 
 export async function checkOJAvailable() {


### PR DESCRIPTION
Enabled passing any options/params to oj submit command.

ex.
```
oj s <url> <filename> -y -w 0
```
would able by
```
acc s -j -y -j -w -j 0
```
