### PR TITLE
update mock-fs to fix tests for node v16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "atcoder-cli",
       "version": "2.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -33,7 +34,7 @@
         "@types/node": "^12.7.5",
         "@types/update-notifier": "^4.1.0",
         "jest": "^24.9.0",
-        "mock-fs": "^4.10.2",
+        "mock-fs": "^5.1.1",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.0",
         "ts-jest": "^24.0.2",
@@ -6381,10 +6382,13 @@
       }
     },
     "node_modules/mock-fs": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.2.tgz",
-      "integrity": "sha512-ewPQ83O4U8/Gd8I15WoB6vgTTmq5khxBskUWCRvswUqjCfOOTREmxllztQOm+PXMWUxATry+VBWXQJloAyxtbQ==",
-      "dev": true
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.1.tgz",
+      "integrity": "sha512-p/8oZ3qvfKGPw+4wdVCyjDxa6wn2tP0TCf3WXC1UyUBAevezPn1TtOoxtMYVbZu/S/iExg+Ghed1busItj2CEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/move-concurrently": {
       "version": "1.0.1",
@@ -14865,9 +14869,9 @@
       }
     },
     "mock-fs": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.2.tgz",
-      "integrity": "sha512-ewPQ83O4U8/Gd8I15WoB6vgTTmq5khxBskUWCRvswUqjCfOOTREmxllztQOm+PXMWUxATry+VBWXQJloAyxtbQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.1.tgz",
+      "integrity": "sha512-p/8oZ3qvfKGPw+4wdVCyjDxa6wn2tP0TCf3WXC1UyUBAevezPn1TtOoxtMYVbZu/S/iExg+Ghed1busItj2CEw==",
       "dev": true
     },
     "move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@types/node": "^12.7.5",
     "@types/update-notifier": "^4.1.0",
     "jest": "^24.9.0",
-    "mock-fs": "^4.10.2",
+    "mock-fs": "^5.1.1",
     "npm-run-all": "^4.1.5",
     "rimraf": "^3.0.0",
     "ts-jest": "^24.0.2",


### PR DESCRIPTION
closes #40 

node v15.11.0 passes all tests, but v16.10.0 fails some tests around `tests/__tests__/template.ts`.
This is fixed by updating mock-fs package.
